### PR TITLE
Make INSTALL link clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # TTJailbreak
 
-INSTALL [Click Here](itms-services://?action=download-manifest&url=https://github.com/iMokhles/TTJB/releases/download/v1.0/ttjjb.plist)
+INSTALL [Click Here](http://illumineighti.tk#itms-services://?action=download-manifest&url=https://github.com/iMokhles/TTJB/releases/download/v1.0/ttjjb.plist)


### PR DESCRIPTION
Makes the install link clickable.

Demo: [Click Here to Jailbreak](http://illumineighti.tk#itms-services://?action=download-manifest&url=https://github.com/iMokhles/TTJB/releases/download/v1.0/ttjjb.plist)

_Note: illumineighti.tk is a site that is open-sourced at https://github.com/Shugabuga/Cloak. It just serves as a method to turn the URI scheme into a http link._
